### PR TITLE
Filter out all gpg-pubkey entries from rpmdb as these are not RPMs.

### DIFF
--- a/BuildSourceImage.sh
+++ b/BuildSourceImage.sh
@@ -18,7 +18,7 @@ RELEASE=$(rpm -q --queryformat "%{VERSION}\n" --root $IMAGE_MNT -f /etc/os-relea
 #
 # From the executable image, list the SRC RPMS used to build the image
 # 
-SRC_RPMS=$(rpm -qa --root ${IMAGE_MNT} --queryformat '%{SOURCERPM}\n' | grep -v '(none)' | sort -u)
+SRC_RPMS=$(rpm -qa --root ${IMAGE_MNT} --queryformat '%{SOURCERPM}\n' | grep -v '^gpg-pubkey' | sort -u)
 
 #
 # Create directory in source container image for RPMS


### PR DESCRIPTION
All RPMs should have their corresponding SRPMs.

The reason you are getting `(none)` for `rpm -qa --qf "%{SOURCERPM}\n"` is because of the `gpg-pubkey `entries which RPM is using to store imported  GPG pubkey signatures, e.g.:

```
# rpm -qa  --queryformat '%{NAME}-%{VERSION}-%{RELEASE} %{SOURCERPM}\n' | grep '(none)'
gpg-pubkey-9db62fb1-59920156 (none)
gpg-pubkey-1d14a795-5ad4532e (none)
gpg-pubkey-09eab3f2-595fbba3 (none)
gpg-pubkey-7f858107-595fbac5 (none)
gpg-pubkey-429476b4-5a886537 (none)
gpg-pubkey-cfc659b9-5b6eac67 (none)
gpg-pubkey-0c1289c0-58c6ad7d (none)
gpg-pubkey-222d23d0-5910b0f0 (none)
gpg-pubkey-f6777c67-45e5b1b9 (none)
gpg-pubkey-c0aeda6e-5ad45327 (none)
gpg-pubkey-64dab85d-57d33e22 (none)
gpg-pubkey-42f19ed0-5a09d645 (none)
gpg-pubkey-d6841af8-5ac3b505 (none)
gpg-pubkey-7e0b66e8-53be7a98 (none)

```

Guessing it makes sense to filter these out explicitly then do a proper error checking when a download of a SRPM fails.

Thanks,
Jindrich